### PR TITLE
Inform about how to create the QR code using shell

### DIFF
--- a/lnd_connect_uri.md
+++ b/lnd_connect_uri.md
@@ -35,7 +35,7 @@ var url = 'lndconnect://' + ip.address() + ':10009?cert=' + cert + '&macaroon=' 
 This is useful when one doesn't want to bring dependencies.
 
 ```
-echo 'lndconnect://example.com?cert='"`grep -v 'CERTIFICATE' tls.cert`"'&macaroon='"`base64 admin.macaroon`" | tr -d '\n' | qrencode -o /tmp/out.png && xdg-open /tmp/out.png
+echo 'lndconnect://example.com?cert='"`grep -v 'CERTIFICATE' tls.cert | tr -d '=' | tr '/+' '_-'`"'&macaroon='"`base64 admin.macaroon | tr -d '=' | tr '/+' '_-'`" | tr -d '\n' | qrencode -o /tmp/out.png
 ```
 
 ## Example:

--- a/lnd_connect_uri.md
+++ b/lnd_connect_uri.md
@@ -35,7 +35,7 @@ var url = 'lndconnect://' + ip.address() + ':10009?cert=' + cert + '&macaroon=' 
 This is useful when one doesn't want to bring dependencies.
 
 ```
-lndconnect://example.com?cert='"`grep -v 'CERTIFICATE' tls.cert`"'&macaroon='"`base64 admin.macaroon`" | tr -d '\n' | qrencode -o /tmp/out.png && xdg-open /tmp/out.png
+echo 'lndconnect://example.com?cert='"`grep -v 'CERTIFICATE' tls.cert`"'&macaroon='"`base64 admin.macaroon`" | tr -d '\n' | qrencode -o /tmp/out.png && xdg-open /tmp/out.png
 ```
 
 ## Example:

--- a/lnd_connect_uri.md
+++ b/lnd_connect_uri.md
@@ -30,6 +30,13 @@ var macaroon = base64url(new Buffer(macaroonData));
 
 var url = 'lndconnect://' + ip.address() + ':10009?cert=' + cert + '&macaroon=' + macaroon
 ```
+### Create and show a QR code using command line
+
+This is useful when one doesn't want to bring dependencies.
+
+```
+lndconnect://example.com?cert='"`grep -v 'CERTIFICATE' tls.cert`"'&macaroon='"`base64 admin.macaroon`" | tr -d '\n' | qrencode -o /tmp/out.png && xdg-open /tmp/out.png
+```
 
 ## Example:
 


### PR DESCRIPTION
People might want to avoid adding another dependencies and compiling stuff for such simple task. The URL can be easily created using shell, so dependencies aren't even needed. This change helps people to use command line, so they don't have to invent it themselves.