### PR TITLE
Add version 2 (reduce QR-Code Density)

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ const (
 	defaultReadMacFilename    = "readonly.macaroon"
 	defaultInvoiceMacFilename = "invoice.macaroon"
 	defaultRPCPort            = 10009
+	defaultVersion            = 2
 )
 
 var (
@@ -55,6 +56,7 @@ type lndConnectConfig struct {
 	Invoice   bool       `long:"invoice" description:"Use invoice macaroon"`
 	Readonly  bool       `long:"readonly" description:"Use readonly macaroon"`
 	Query     arrayFlags `short:"q" long:"query" description:"Add additional url query parameters"`
+	Version   uint8      `short:"v" long:"version" description:"The lndconnect version to use"`
 }
 
 // config defines the configuration options for lndconnect.
@@ -100,6 +102,7 @@ type config struct {
 func loadConfig() (*config, error) {
 	defaultCfg := config{
 		LndConnect: &lndConnectConfig{
+			Version: defaultVersion,
 			Port: defaultRPCPort,
 		},
 		LndDir:      defaultLndDir,

--- a/lndconnect_test.go
+++ b/lndconnect_test.go
@@ -7,6 +7,7 @@ func ExampleLocalhost() {
 		LndConnect: &lndConnectConfig{
 			Localhost: true,
 			Url:       true,
+			Version:      1,
 		},
 	}
 	displayLink(c)
@@ -22,6 +23,7 @@ func ExampleQuery() {
 			Localhost: true,
 			Url:       true,
 			Query:     arrayFlags{"test=abc"},
+			Version:      1,
 		},
 	}
 	displayLink(c)
@@ -37,6 +39,7 @@ func ExamplePort() {
 			Localhost: true,
 			Url:       true,
 			Port:      123,
+			Version:      1,
 		},
 	}
 	displayLink(c)
@@ -52,6 +55,7 @@ func ExampleHost() {
 			Localhost: true,
 			Url:       true,
 			Host:      "1.2.3.4",
+			Version:      1,
 		},
 	}
 	displayLink(c)
@@ -68,9 +72,90 @@ func ExampleNoCert() {
 			Url:       true,
 			Host:      "1.2.3.4",
 			NoCert:    true,
+			Version:      1,
 		},
 	}
 	displayLink(c)
 
 	// Output: lndconnect://1.2.3.4:0?macaroon=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA
+}
+
+func ExampleLocalhostV2() {
+	c := &config{
+		TLSCertPath:  "testdata/tls.cert",
+		AdminMacPath: "testdata/admin.macaroon",
+		LndConnect: &lndConnectConfig{
+			Localhost: true,
+			Url:       true,
+			Version:      2,
+		},
+	}
+	displayLink(c)
+
+	// Output: lndconn://127.0.0.1:0?c=somNeor-nJza1UFoBULswg6lRo3f1_-euBY7zV2DIUk&m=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA&v=2
+}
+
+func ExampleQueryV2() {
+	c := &config{
+		TLSCertPath:  "testdata/tls.cert",
+		AdminMacPath: "testdata/admin.macaroon",
+		LndConnect: &lndConnectConfig{
+			Localhost: true,
+			Url:       true,
+			Query:     arrayFlags{"test=abc"},
+			Version:      2,
+		},
+	}
+	displayLink(c)
+
+	// Output: lndconn://127.0.0.1:0?c=somNeor-nJza1UFoBULswg6lRo3f1_-euBY7zV2DIUk&m=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA&test=abc&v=2
+}
+
+func ExamplePortV2() {
+	c := &config{
+		TLSCertPath:  "testdata/tls.cert",
+		AdminMacPath: "testdata/admin.macaroon",
+		LndConnect: &lndConnectConfig{
+			Localhost: true,
+			Url:       true,
+			Port:      123,
+			Version:      2,
+		},
+	}
+	displayLink(c)
+
+	// Output: lndconn://127.0.0.1:123?c=somNeor-nJza1UFoBULswg6lRo3f1_-euBY7zV2DIUk&m=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA&v=2
+}
+
+func ExampleHostV2() {
+	c := &config{
+		TLSCertPath:  "testdata/tls.cert",
+		AdminMacPath: "testdata/admin.macaroon",
+		LndConnect: &lndConnectConfig{
+			Localhost: true,
+			Url:       true,
+			Host:      "1.2.3.4",
+			Version:      2,
+		},
+	}
+	displayLink(c)
+
+	// Output: lndconn://1.2.3.4:0?c=somNeor-nJza1UFoBULswg6lRo3f1_-euBY7zV2DIUk&m=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA&v=2
+}
+
+func ExampleNoCertV2() {
+	c := &config{
+		TLSCertPath:  "testdata/tls.cert",
+		AdminMacPath: "testdata/admin.macaroon",
+		LndConnect: &lndConnectConfig{
+			Localhost: true,
+			Url:       true,
+			Host:      "1.2.3.4",
+			NoCert:    true,
+			Version:      2,
+		},
+	}
+	displayLink(c)
+
+	// Output: lndconn://1.2.3.4:0?m=AgEDbG5kArsBAwoQ3_I9f6kgSE6aUPd85lWpOBIBMBoWCgdhZGRyZXNzEgRyZWFkEgV3cml0ZRoTCgRpbmZvEgRyZWFkEgV3cml0ZRoXCghpbnZvaWNlcxIEcmVhZBIFd3JpdGUaFgoHbWVzc2FnZRIEcmVhZBIFd3JpdGUaFwoIb2ZmY2hhaW4SBHJlYWQSBXdyaXRlGhYKB29uY2hhaW4SBHJlYWQSBXdyaXRlGhQKBXBlZXJzEgRyZWFkEgV3cml0ZQAABiAiUTBv3Eh6iDbdjmXCfNxp4HBEcOYNzXhrm-ncLHf5jA&v=2
 }


### PR DESCRIPTION
This PR is a draft and open for discussion.

The main goal is to reduce the density of the lndconnect QR-Code, which causes problems on some scanning devices and leads to bad UX in general.

In the proposed solution there are two notable changes:
- the introduction of a versioning system
- optimizations to reduce density

Until now, no versioning system exists.
That's why for version 2 I changed the Uri from lndconnect:// to lndconn://
By doing this we will not break any existing implementations.
In the new version a query param "v" is added which is used for versioning to allow future updates.
In the current proposal the new version (2) is the default and you have to explicitly use --version=1 to generate an old connect string.

**Density optimizations:**
- sha256 of the certificate instead of the full certificate
- shorter names (lndconnect > lndconn, cert > c; macaroon > m)
- QR-Code error correction reduced to low for both terminal and image QR-Code.

The error correction reduction for the QR-Code is also done for version 1 in this PR as it is a non breaking change.

**Comparison images:**
v1 - old:
![v1-old](https://user-images.githubusercontent.com/15313630/92333339-e5349800-f084-11ea-8def-66daff5febd4.png)

v1 - new:
![v1-new](https://user-images.githubusercontent.com/15313630/92333343-e8c81f00-f084-11ea-94bc-2d07b1a2453e.png)

v2:
![v2](https://user-images.githubusercontent.com/15313630/92333345-ef569680-f084-11ea-87fd-e953486823d5.png)

I successfully tested certificate validation by hash on a custom build of Zap Android to proof that v2 is actually working.

This PR does not include an update for the documentation. I can add that later when we come to an consensus on what to do :)

**Alternative solution:**
Instead of a version 2 we could also just add a --certificateHash flag and reduce the error correction levels to low. The density reduction from shortening names is marginal and can be omitted.
It is a simple change but that would mean wallets that already support lndconnect would receive certificate hashes instead of full certificates without knowing it and fail although they claim to support it. (As long as they don't support the new specs)
For backwards compatibility wallets would have to implement a check of the certificate length. If it matches 32 byte (sha256 length) it is clear that the certificate is hashed, if not, it should be treated as a full certificate.

**Additional note:**
It might be possible to further reduce density by encoding with bech32 and use the upper case version, but that seems like it makes implementation of lndconnect unnecessarily complex for little benefit. With the optimizations from above the code is already easy to scan again.